### PR TITLE
fix: use `Hash256,int` for marker as field type instead of `Hash256`

### DIFF
--- a/websockets/commands.go
+++ b/websockets/commands.go
@@ -230,17 +230,17 @@ type AccountInfoResult struct {
 
 type AccountLinesCommand struct {
 	*Command
-	Account     data.Account        `json:"account"`
-	Limit       uint32              `json:"limit"`
-	LedgerIndex interface{}         `json:"ledger_index,omitempty"`
-	Marker      *data.Hash256       `json:"marker,omitempty"`
-	Result      *AccountLinesResult `json:"result,omitempty"`
+	Account     data.Account          `json:"account"`
+	Limit       uint32                `json:"limit"`
+	LedgerIndex interface{}           `json:"ledger_index,omitempty"`
+	Marker      *data.ExtendedHash256 `json:"marker,omitempty"`
+	Result      *AccountLinesResult   `json:"result,omitempty"`
 }
 
 type AccountLinesResult struct {
 	LedgerSequence *uint32               `json:"ledger_index"`
 	Account        data.Account          `json:"account"`
-	Marker         *data.Hash256         `json:"marker"`
+	Marker         *data.ExtendedHash256 `json:"marker"`
 	Lines          data.AccountLineSlice `json:"lines"`
 }
 

--- a/websockets/remote.go
+++ b/websockets/remote.go
@@ -385,7 +385,7 @@ func (r *Remote) AccountInfo(a data.Account) (*AccountInfoResult, error) {
 func (r *Remote) AccountLines(account data.Account, ledgerIndex interface{}) (*AccountLinesResult, error) {
 	var (
 		lines  data.AccountLineSlice
-		marker *data.Hash256
+		marker *data.ExtendedHash256
 	)
 	for {
 		cmd := &AccountLinesCommand{


### PR DESCRIPTION
According to the (inline) doc the marker is of type Hash256. Reality the marker (of at least) used in the account_lines is of type 'Hash256,int'

Solution: Introduction of a new type, here called ExtendedHash, which checks dynamically for marker (Hash256) and for the returned format 'Hash256,int'
Test run with a extended set (use the solo coin for example; 1000s of account lines) with the lines.go program shows the expected result (Previous result was a json Unmarshal error on the , in the marker).