### PR TITLE
feat: Gateway balances

### DIFF
--- a/websockets/commands.go
+++ b/websockets/commands.go
@@ -299,3 +299,18 @@ type FeeResult struct {
 	MaxQueueSize uint32 `json:"max_queue_size,string"`
 	Status       string `json:"status"`
 }
+
+type GatewayBalances struct {
+	*Command
+	Account data.Account           `json:"account"`
+	Strict  bool                   `json:"strict,omitempty"`
+	Result  *GatewayBalancesResult `json:"result,omitempty"`
+}
+
+type GatewayBalancesResult struct {
+	Obligations *map[string]string `json:"obligations"`
+	Account     string             `json:"account"`
+	LedgerIndex uint32             `json:"ledger_index"`
+	LedgerHash  string             `json:"ledger_hash"`
+	Validated   bool               `json:"validated"`
+}

--- a/websockets/remote.go
+++ b/websockets/remote.go
@@ -464,7 +464,7 @@ func (r *Remote) BookOffers(taker data.Account, ledgerIndex interface{}, pays, g
 	return cmd.Result, nil
 }
 
-// Execute an account commnad
+// Load Gateway Balances for the given account
 func (r *Remote) GatewayBalances(a data.Account) (*GatewayBalancesResult, error) {
 	cmd := &GatewayBalances{
 		Command: newCommand("gateway_balances"),

--- a/websockets/remote.go
+++ b/websockets/remote.go
@@ -464,6 +464,21 @@ func (r *Remote) BookOffers(taker data.Account, ledgerIndex interface{}, pays, g
 	return cmd.Result, nil
 }
 
+// Execute an account commnad
+func (r *Remote) GatewayBalances(a data.Account) (*GatewayBalancesResult, error) {
+	cmd := &GatewayBalances{
+		Command: newCommand("gateway_balances"),
+		Account: a,
+		Strict:  true,
+	}
+	r.outgoing <- cmd
+	<-cmd.Ready
+	if cmd.CommandError != nil {
+		return nil, cmd.CommandError
+	}
+	return cmd.Result, nil
+}
+
 // Synchronously subscribe to streams and receive a confirmation message
 // Streams are recived asynchronously over the Incoming channel
 func (r *Remote) Subscribe(ledger, transactions, transactionsProposed, server bool) (*SubscribeResult, error) {


### PR DESCRIPTION
- The ripple api as implemented does not provide raw access for methods (yet), thus requiring new functionalities to be added in the functional style. The new exposed functionality is for the gateway_balance command